### PR TITLE
Bump `gpu-allocator`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ ash = "0.33.2"
 bytemuck = "1.5.0"
 copypasta = "0.7.1"
 egui = "0.14.2"
-gpu-allocator = { version = "0.9.0", optional = true }
+gpu-allocator = { version = "0.10.0", optional = true }
 webbrowser = "0.5.5"
 winit = "0.25.0"
 


### PR DESCRIPTION
Hey, thanks for providing this crate! `gpu-allocator` is now at version `0.10` so I updated it to get it to work with my code.