### PR TITLE
Integration::new(): allow any type implementing HasRawDisplayHandle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bytemuck = "1.7.3"
 egui = "0.23.0"
 egui-winit = { version = "0.23.0", default-features = false }
 gpu-allocator = { version = "0.23.0", default-features = false, features = ["vulkan"], optional = true }
+raw-window-handle = { version="0.5.0" }
 
 [dev-dependencies]
 ash-window = "0.12.0"
@@ -50,7 +51,6 @@ memoffset = "0.9.0"
 mint = "0.5.9"
 tobj = "4.0.0"
 ash = { version="0.37.1", default-features = false, features = ["linked", "debug"] }
-raw-window-handle = { version="0.5.0" }
 
 [dev-dependencies.cgmath]
 version = "0.18.0"

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -6,10 +6,8 @@ use egui::{
     epaint::{ahash::AHashMap, ImageDelta},
     Context, TextureId, TexturesDelta,
 };
-use egui_winit::{
-    winit::{event_loop::EventLoop, window::Window},
-    EventResponse,
-};
+use egui_winit::{winit::window::Window, EventResponse};
+use raw_window_handle::HasRawDisplayHandle;
 use std::ffi::CString;
 
 use crate::{utils::insert_image_memory_barrier, *};
@@ -50,8 +48,8 @@ pub struct Integration<A: AllocatorTrait> {
 }
 impl<A: AllocatorTrait> Integration<A> {
     /// Create an instance of the integration.
-    pub fn new<T>(
-        event_loop: &EventLoop<T>,
+    pub fn new<H: HasRawDisplayHandle>(
+        display_target: &H,
         physical_width: u32,
         physical_height: u32,
         scale_factor: f64,
@@ -70,7 +68,7 @@ impl<A: AllocatorTrait> Integration<A> {
         context.set_fonts(font_definitions);
         context.set_style(style);
 
-        let mut egui_winit = egui_winit::State::new(&event_loop);
+        let mut egui_winit = egui_winit::State::new(display_target);
         egui_winit.set_pixels_per_point(scale_factor as f32);
 
         // Get swap_images to get len of swapchain images and to create framebuffers


### PR DESCRIPTION
Previously, to create an `Integration` an event loop must have been passed as the first argument.
The only place where the event loop is used is in `Integration::new()`, where it's uset to create an `egui_winit::State`, which accepts a reference to any type implementing `HasRawDisplayHandle`.

By implementing this change, winit `Window`s can be used to create an integration as well, which can be useful when an event loop isn't available.

To implement this change, the `raw-window-handle` had to be promoted to a crate dependency