### PR TITLE
Reuse descriptor sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ bytemuck = "1.7.3"
 egui = "0.23.0"
 egui-winit = { version = "0.23.0", default-features = false }
 gpu-allocator = { version = "0.23.0", default-features = false, features = ["vulkan"], optional = true }
+log = "0.4.20"
 raw-window-handle = { version="0.5.0" }
 
 [dev-dependencies]
@@ -51,6 +52,7 @@ memoffset = "0.9.0"
 mint = "0.5.9"
 tobj = "4.0.0"
 ash = { version="0.37.1", default-features = false, features = ["linked", "debug"] }
+env_logger = "0.11.0"
 
 [dev-dependencies.cgmath]
 version = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ mint = "0.5.9"
 tobj = "4.0.0"
 ash = { version="0.37.1", default-features = false, features = ["linked", "debug"] }
 env_logger = "0.11.0"
+rfd = "0.13.*"
 
 [dev-dependencies.cgmath]
 version = "0.18.0"

--- a/examples/example/main.rs
+++ b/examples/example/main.rs
@@ -1827,6 +1827,7 @@ impl Drop for App {
 }
 
 fn main() -> Result<()> {
+    env_logger::init();
     let event_loop = EventLoop::new();
     let mut app = App::new(&event_loop)?;
     event_loop.run(move |event, _, control_flow| {

--- a/examples/user_texture/main.rs
+++ b/examples/user_texture/main.rs
@@ -2086,6 +2086,7 @@ impl Drop for App {
 }
 
 fn main() -> Result<()> {
+    env_logger::init();
     let event_loop = EventLoop::new();
     let mut app = App::new(&event_loop)?;
 

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -1188,14 +1188,21 @@ impl<A: AllocatorTrait> Integration<A> {
                 .image_layout(vk::ImageLayout::SHADER_READ_ONLY_OPTIMAL)
                 .sampler(self.sampler)
                 .build();
-            let dsc_writes = [vk::WriteDescriptorSet::builder()
+            let infos = [image_info];
+            let dsc_write = vk::WriteDescriptorSet::builder()
                 .dst_set(dsc_set.set)
                 .descriptor_type(vk::DescriptorType::COMBINED_IMAGE_SAMPLER)
                 .dst_array_element(0_u32)
                 .dst_binding(0_u32)
-                .image_info(&[image_info])
-                .build()];
+                .image_info(&infos)
+                .build();
+
+            let dsc_writes = [dsc_write];
             unsafe {
+                assert!(dsc_writes[0].descriptor_count == 1);
+                assert!(
+                    dsc_writes[0].p_image_info.as_ref().unwrap().image_view != ImageView::null()
+                );
                 self.device.update_descriptor_sets(&dsc_writes, &[]);
             }
             // register new texture
@@ -1637,6 +1644,8 @@ impl<A: AllocatorTrait> Integration<A> {
             )
         }
         .expect("Failed to create descriptor pool.");
+
+        println!("Create new pool");
 
         let info = DescriptorPoolInfo {
             pool,


### PR DESCRIPTION
While working on my project, i reached a point where my application was consistently panicking due to an OUT_OF_POOL_MEMORY error: i thus noticed that this library only uses a single descriptor pool, whose maximum allocations can only hold up to 1024 descriptor sets.

This PR implements a dynamic descriptor pool allocation system,  where each pool tracks how many descriptor sets were allocated from it: once all of the pools are full, when a new descriptor set is needed a new descriptor pool is created.
Furthermore, this pr also tries to reuse descriptor sets when possible, by storing unused descriptor sets in a list (e.g a user texture is unregistered -> store the descriptor set somewhere -> a new user texture is registered -> reuse the previously stored descriptor set)